### PR TITLE
Add Magento lifecycle matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository is an up-to-date table of the versions of various software that various versions of Magento support.
 
+## Magento Lifecycle
+
+| Magento Minor Version | Release Date | End of Quality Fixes | End of Security Fixes/End of Software Support |
+|:---|---|---|---|
+|2.2|September 2017|December 2019|December 2019|
+|2.3|November 2018|July 2021|April 2022|
+|2.4|July 2020|||
+
 ## PHP
 
 | Magento Minor Version | PHP 5.5 | PHP 5.6 | PHP 7.0 | PHP 7.1 | PHP 7.2 | PHP 7.3 | PHP 7.4 |

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Magento 2 Supported Versions
-
-This repository is an up-to-date table of the versions of various software that various versions of Magento support.
-
-## Magento Lifecycle
+# Magento EOL
 
 | Magento Minor Version | Release Date | End of Quality Fixes | End of Security Fixes/End of Software Support |
 |:---|---|---|---|
-|2.2|September 2017|December 2019|December 2019|
+|2.0|November 2015|**March 2018**|**March 2018**|
+|2.1|June 2016|**June 2019**|**June 2019**|
+|2.2|September 2017|**December 2019**|**December 2019**|
 |2.3|November 2018|July 2021|April 2022|
 |2.4|July 2020|||
+
+# Supported Software
 
 ## PHP
 


### PR DESCRIPTION
To improve the overall idea of support for Magento versions, I added the Magento Lifecycle matrix. The matrix is based on [Lifecycle Policy](https://devdocs.magento.com/release/lifecycle-policy.html).

I also added the 2.2 version to inform readers about the EOL.

This is just a suggestion. If you do not like it, do not bother to decline!

